### PR TITLE
set killmode/killsignal in systemd example

### DIFF
--- a/dist/systemd/nomad.service
+++ b/dist/systemd/nomad.service
@@ -3,6 +3,8 @@ Description=Nomad
 Documentation=https://nomadproject.io/docs/
 
 [Service]
+KillMode=process
+KillSignal=SIGINT
 ExecStart=/usr/bin/nomad agent -config /etc/nomad
 ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=65536


### PR DESCRIPTION
The default (`control-group`) kill mode in systemd will kill the associated executors, leading to a commonly seen behavior of nomad client restarts losing all current allocations.

setting the `KillSignal` to `SIGINT` seems to be a reasonable default, and allows things like leave_on_interrupt to function